### PR TITLE
Valid link for tutorials

### DIFF
--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -22,7 +22,7 @@ export default function Navbar() {
             <a href="docs">Documentation</a>
           </li>
           <li>
-            <a href="tutorials">Tutorials</a>
+            <a href="docs/#tutorials">Tutorials</a>
           </li>
           <li>
             <a href="https://github.com/pygame-community/pygame-ce">Contribute</a>


### PR DESCRIPTION
I'm tired of well meaning people reporting a 404 link from clicking on the tutorial link.

I know @novialriptide you were talking about having `/tutorial` on the site actual be a place someday, but for now I think this is a good improvement.

(This is untested, I haven't set up a dev environment for the site, but I'm pretty confident this 1 line change will work)