### PR TITLE
Footer displayed correctly on mobile, fix for issue #25

### DIFF
--- a/src/styles/footer.module.css
+++ b/src/styles/footer.module.css
@@ -6,7 +6,14 @@
 
 .footerCol {
   padding: 30px;
-  width: 30%;
+  min-width: 30%;
+  max-width: 30%;
+}
+
+@media (max-width: 768px) {
+  .footerCol {
+    max-width: 60%;
+  }
 }
 
 .footerCol ul {


### PR DESCRIPTION
Have been wanting to contribute to for a while. Issue seemed like an easy fix / good first issue and had been open for a while without a fix.

See attached image for how it looks on mobile now (using firefox devtools):
![image](https://github.com/user-attachments/assets/1dad1b79-36b9-45c3-89de-6803c95c602a)