### PR TITLE
Update action dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: ['3.11']
     steps:
       # Build documentation pages
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v4
+      - uses: actions/cache@v4
         name: Configure npm caching
         with:
           path: ~/.npm
@@ -23,7 +23,7 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
           options: '--check --verbose'


### PR DESCRIPTION
The page uploads have failed, which I would like to restore for 2.5.4 docs.

I don't have prettier installed, to fix the prettier thing, so I'm disregarding for now.