### PR TITLE
Update all discord custom invite URLs to 'https//pyga.me/discord' URL

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -24,7 +24,7 @@ export default function Footer() {
             <Link href="https://github.com/pygame-community">GitHub</Link>
           </li>
           <li>
-            <Link href="https://discord.gg/pygame">Discord</Link>
+            <Link href="/discord">Discord</Link>
           </li>
         </ul>
       </div>

--- a/src/components/get-involved.tsx
+++ b/src/components/get-involved.tsx
@@ -10,7 +10,7 @@ export default function GetInvolved() {
         introducing new features to the pygame API.
         <div style={{ display: 'flex', marginTop: '10px' }}>
           <Button text="GitHub" fontSize="1.2rem" link="https://github.com/pygame-community" />
-          <Button text="Discord" fontSize="1.2rem" link="https://discord.gg/pygame" />
+          <Button text="Discord" fontSize="1.2rem" link="/discord" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Updates all 'https://discord.gg/pygame' URLs in the HTML to the newly added 'https://pyga.me/discord' URL. Similarly minimal in impact since the current URL doesn't work at all.